### PR TITLE
str2num accepts char array, not string

### DIFF
--- a/new_matlab/parselog.m
+++ b/new_matlab/parselog.m
@@ -152,7 +152,7 @@ function s = splitlog(filename, gen_files)
          elseif contains(tline, '<aircraft')
              % Create a new aircraft
              aircraft.name = string(regexpi(tline, 'name="([^"]+)"', 'tokens'));
-             aircraft.id = str2num(string(regexpi(tline, 'ac_id="([^"]+)"', 'tokens')));
+             aircraft.id = str2num(char(string(regexpi(tline, 'ac_id="([^"]+)"', 'tokens'))));
              aircraft.filename = strcat(filepath, filesep, name, '_ac', string(aircraft.id), '.xml');
              s.aircrafts(aircraft.id) = aircraft;
              


### PR DESCRIPTION
Oddly enough str2num does not accept strings but character vectors, so str2num(string(... does not work
(try str2num('24') -> works, str2num("24") -> does not work)

This is for matlab r2017b by the way